### PR TITLE
Don't fail if audio device can't be opened

### DIFF
--- a/src/tsdl_new.c
+++ b/src/tsdl_new.c
@@ -123,11 +123,6 @@ PrivateAudioDevice* initAudio(){
       caml_failwith("SDL_INIT_AUDIO not initialized");
   }
 
-  if((gDevice->device = SDL_OpenAudioDevice(NULL, 0, &(gDevice->want), NULL, SDL_AUDIO_ALLOW_CHANGES)) == 0) {
-    fprintf(stderr, "[%s: %d]Warning: failed to open audio device: %s\n", __FILE__, __LINE__, SDL_GetError());
-    caml_failwith("Failed to open audio device");
-  }
-
   (gDevice->want).freq = AUDIO_FREQUENCY;
   (gDevice->want).format = AUDIO_FORMAT;
   (gDevice->want).channels = AUDIO_CHANNELS;


### PR DESCRIPTION
Removes a redundant call to SDL_OpenAudioDevice.

Opening the device currently fails on Linux, but this should at least allow things to run without sound. Another attempt to open the device is made almost immediately after the removed code, and it displays a warning instead of failing altogether.