### PR TITLE
Add support for creating and setting custom cursors

### DIFF
--- a/src/tsdl_new.c
+++ b/src/tsdl_new.c
@@ -383,16 +383,16 @@ CAMLprim value TSDL_GL_GetDrawableSize(value window) {
 CAMLprim value TSDL_GetDisplayDPI(value window) {
   CAMLparam1(window);
   CAMLlocal1(ret);
-  
+
   float ddpi, hdpi, vdpi;
   int index = SDL_GetWindowDisplayIndex((SDL_Window *)Field(window, 0));
   SDL_GetDisplayDPI(index, &ddpi, &hdpi, &vdpi);
-  
+
   ret = caml_alloc_small(3, Double_array_tag);
   Double_field(ret, 0) = ddpi;
   Double_field(ret, 1) = hdpi;
   Double_field(ret, 2) = vdpi;
-  
+
   CAMLreturn(ret);
 }
 
@@ -407,4 +407,18 @@ CAMLprim value TSDL_GetWindowMaximumSize(value window) {
   Field(ret, 1) = Val_int(h);
 
   CAMLreturn(ret);
+}
+
+CAMLprim value TSDL_CreateColorCursor(value surface, value hot_x, value hot_y) {
+  CAMLparam3(surface, hot_x, hot_y);
+  CAMLlocal1(ret);
+  ret = caml_alloc_small(1, Abstract_tag);
+  Field(ret, 0) = (long)SDL_CreateColorCursor((SDL_Surface *)Field(surface, 0), Int_val(hot_x), Int_val(hot_y));
+  CAMLreturn(ret);
+}
+
+void TSDL_SetCursor(value cursor) {
+  CAMLparam1(cursor);
+  SDL_SetCursor((SDL_Cursor *)Field(cursor, 0));
+  CAMLreturn0;
 }

--- a/src/tsdl_new.re
+++ b/src/tsdl_new.re
@@ -86,6 +86,12 @@ type dpiT = {
 
 external get_window_dpi : windowT => dpiT = "TSDL_GetDisplayDPI";
 
+type surfaceT;
+type cursorT;
+
+external set_cursor : cursorT => unit = "TSDL_SetCursor";
+external create_color_cursor : (surfaceT, int, int) => cursorT = "TSDL_CreateColorCursor";
+
 module Init = {
   let timer = 1;
   let audio = 16;
@@ -150,8 +156,6 @@ type int64T;
 external get_time_diff : (int64T, int64T) => float = "TGetTimeDiff";
 
 [@noalloc] external gl_swap_window : windowT => unit = "TSDL_GL_SwapWindow";
-
-type surfaceT;
 
 external get_window_surface : windowT => surfaceT = "TSDL_GetWindowSurface";
 


### PR DESCRIPTION
Currently using like:
```
let surface = Sdl.load_bmp(filePath);
let cursor = Sdl.create_color_cursor(surface, 0, 0);
Sdl.set_cursor(cursor);
```